### PR TITLE
Add Support for XMRig

### DIFF
--- a/Include.ps1
+++ b/Include.ps1
@@ -258,6 +258,28 @@ function Get-HashRate {
                     Start-Sleep $Interval
                 } while ($HashRates.Count -lt 6)
             }
+			"XMRig" {
+                $Message = "summary"
+
+                do {
+                  
+					$Request = Invoke-WebRequest "http://$($Server):$Port/h" -UseBasicParsing
+					
+					$Data = $Request | ConvertFrom-Json
+
+					$HashRate = [Double]$Data.hashrate.total[0]
+					if ($HashRate -eq "") {$HashRate = [Double]$Data.hashrate.total[1]}
+                    if ($HashRate -eq "") {$HashRate = [Double]$Data.hashrate.total[2]}
+					
+					if ($HashRate -eq $null) {$HashRates = @(); break}
+
+                    $HashRates += [Double]$HashRate
+
+                    if (-not $Safe) {break}
+					
+					Start-Sleep $Interval
+                }while ($HashRates.count -lt 6)
+            }
 			"dstm" {
                 $Message = "summary"
 

--- a/Include.ps1
+++ b/Include.ps1
@@ -258,26 +258,26 @@ function Get-HashRate {
                     Start-Sleep $Interval
                 } while ($HashRates.Count -lt 6)
             }
-			"XMRig" {
+	    "XMRig" {
                 $Message = "summary"
 
                 do {
                   
-					$Request = Invoke-WebRequest "http://$($Server):$Port/h" -UseBasicParsing
+			$Request = Invoke-WebRequest "http://$($Server):$Port/h" -UseBasicParsing
 					
-					$Data = $Request | ConvertFrom-Json
+			$Data = $Request | ConvertFrom-Json
 
-					$HashRate = [Double]$Data.hashrate.total[0]
-					if ($HashRate -eq "") {$HashRate = [Double]$Data.hashrate.total[1]}
-                    if ($HashRate -eq "") {$HashRate = [Double]$Data.hashrate.total[2]}
+			$HashRate = [Double]$Data.hashrate.total[0]
+			if ($HashRate -eq "") {$HashRate = [Double]$Data.hashrate.total[1]}
+                   	if ($HashRate -eq "") {$HashRate = [Double]$Data.hashrate.total[2]}
 					
-					if ($HashRate -eq $null) {$HashRates = @(); break}
+			if ($HashRate -eq $null) {$HashRates = @(); break}
 
-                    $HashRates += [Double]$HashRate
+                    	$HashRates += [Double]$HashRate
 
-                    if (-not $Safe) {break}
+                   	if (-not $Safe) {break}
 					
-					Start-Sleep $Interval
+			Start-Sleep $Interval
                 }while ($HashRates.count -lt 6)
             }
 			"dstm" {

--- a/Miners/XMRig.ps1
+++ b/Miners/XMRig.ps1
@@ -4,8 +4,8 @@ $Path = ".\Bin\NVIDIA-XMRig\xmrig-nvidia.exe"
 $Uri = "https://github.com/xmrig/xmrig-nvidia/releases/download/v2.4.2/xmrig-nvidia-2.4.2-cuda9-win64.zip"
 
 $Commands = [PSCustomObject]@{
-    "cryptonight" = " --cuda-devices $SelGPUCC --cuda-launch=42x18" #Cryptonight
-	"cryptonight-lite" = " --cuda-devices $SelGPUCC --cuda-launch=42x18" #Cryptonight-lite
+    "cryptonight" = " --cuda-devices $SelGPUCC --cuda-launch=16x150" #Cryptonight
+	"cryptonight-lite" = " --cuda-devices $SelGPUCC --cuda-launch=16x150" #Cryptonight-lite
 }
 $Port = 2222
 $Name = (Get-Item $script:MyInvocation.MyCommand.Path).BaseName

--- a/Miners/XMRig.ps1
+++ b/Miners/XMRig.ps1
@@ -1,0 +1,24 @@
+. .\Include.ps1
+
+$Path = ".\Bin\NVIDIA-XMRig\xmrig-nvidia.exe"
+$Uri = "https://github.com/xmrig/xmrig-nvidia/releases/download/v2.4.2/xmrig-nvidia-2.4.2-cuda9-win64.zip"
+
+$Commands = [PSCustomObject]@{
+    "cryptonight" = " --cuda-devices $SelGPUCC --cuda-launch=42x18" #Cryptonight
+	"cryptonight-lite" = " --cuda-devices $SelGPUCC --cuda-launch=42x18" #Cryptonight-lite
+}
+$Port = 2222
+$Name = (Get-Item $script:MyInvocation.MyCommand.Path).BaseName
+
+$Commands | Get-Member -MemberType NoteProperty | Select -ExpandProperty Name | ForEach {
+   [PSCustomObject]@{
+		Type = "NVIDIA"
+		Path = $Path
+		Arguments = "-a $_ -o stratum+tcp://$($Pools.(Get-Algorithm($_)).Host):$($Pools.(Get-Algorithm($_)).Port) -u $($Pools.(Get-Algorithm($_)).User) -p $($Pools.(Get-Algorithm($_)).Pass)$($Commands.$_) --api-port $port --donate-level 1"
+        HashRates = [PSCustomObject]@{(Get-Algorithm($_)) = $Stats."$($Name)_$(Get-Algorithm($_))_HashRate".Week}
+        API = "XMRig"
+        Port = $Port
+        Wrap = $false
+        URI = $Uri    
+    }
+}


### PR DESCRIPTION
The proposed code adds support for XMRig as requested in https://github.com/nemosminer/NemosMiner-v2.3/issues/84

The main issue I have with the implementation is in the Thread & Block settings in xmrig.ps1 file.  I tested this briefly on a 1070ti at 16x150 (TxB) and got around 635 H/s.  The problem is that this is going to be pretty specific for each card.  When I didn't include "--cuda-launch", the miner would crash with the error "out of memory."  Unfortunately, I don't understand the cryptonight algorithm enough to improve this part of the script.  
  